### PR TITLE
11-create-job-to-feed-data

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -139,6 +139,17 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-crontab"
+version = "0.7.1"
+description = "dead simple crontab powered job scheduling for django"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Django = ">=1.8"
+
+[[package]]
 name = "django-extensions"
 version = "3.1.5"
 description = "Extensions for Django"
@@ -633,7 +644,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "309ab2d46403150a452002eff35eb354e3e56def50b962d89183f6aef4f724ed"
+content-hash = "e388cbe07f621bb1e7b9a99788a9aa31119327bbfb5fcfbb88b2855fd5c90dbf"
 
 [metadata.files]
 appnope = [
@@ -687,6 +698,9 @@ decorator = [
 django = [
     {file = "Django-3.2.9-py3-none-any.whl", hash = "sha256:e22c9266da3eec7827737cde57694d7db801fedac938d252bf27377cec06ed1b"},
     {file = "Django-3.2.9.tar.gz", hash = "sha256:51284300f1522ffcdb07ccbdf676a307c6678659e1284f0618e5a774127a6a08"},
+]
+django-crontab = [
+    {file = "django-crontab-0.7.1.tar.gz", hash = "sha256:1201810a212460aaaa48eb6a766738740daf42c1a4f6aafecfb1525036929236"},
 ]
 django-extensions = [
     {file = "django-extensions-3.1.5.tar.gz", hash = "sha256:28e1e1bf49f0e00307ba574d645b0af3564c981a6dfc87209d48cb98f77d0b1a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ django-solo = "^2.0.0"
 psycopg2-binary = "^2.9.3"
 drf-yasg = "^1.20.0"
 whitenoise = "^6.0.0"
+django-crontab = "^0.7.1"
 
 [tool.poetry.dev-dependencies]
 django-extensions = "^3.1.5"

--- a/quotation_system/settings.py
+++ b/quotation_system/settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     # Third party apps
+    'django_crontab',
     'rest_framework',
     'solo',
     'drf_yasg',
@@ -133,3 +134,7 @@ STATICFILES_DIRS = [
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CRONJOBS = [
+    ('0 17 * * *', 'django.core.management.call_command', ['set_up_data']),
+]


### PR DESCRIPTION
- add django_crontab
- add crontab to search for new api data every day